### PR TITLE
Enable I2C Slave mode with input-only pin as SCL.

### DIFF
--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -871,10 +871,15 @@ esp_err_t i2c_set_pin(i2c_port_t i2c_num, int sda_io_num, int scl_io_num, bool s
         esp_rom_gpio_connect_in_signal(sda_io_num, sda_in_sig, 0);
     }
     if (scl_io_num >= 0) {
-        gpio_set_level(scl_io_num, I2C_IO_INIT_LEVEL);
-        gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[scl_io_num], PIN_FUNC_GPIO);
-        gpio_set_direction(scl_io_num, GPIO_MODE_INPUT_OUTPUT_OD);
-        esp_rom_gpio_connect_out_signal(scl_io_num, scl_out_sig, 0, 0);
+        if (mode == I2C_MODE_MASTER) {
+            gpio_set_level(scl_io_num, I2C_IO_INIT_LEVEL);
+            gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[scl_io_num], PIN_FUNC_GPIO);
+            gpio_set_direction(scl_io_num, GPIO_MODE_INPUT_OUTPUT_OD);
+            esp_rom_gpio_connect_out_signal(scl_io_num, scl_out_sig, 0, 0);
+        } else {
+            gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[scl_io_num], PIN_FUNC_GPIO);
+            gpio_set_direction(scl_io_num, GPIO_MODE_INPUT);
+        }
         esp_rom_gpio_connect_in_signal(scl_io_num, scl_in_sig, 0);
         if (scl_pullup_en == GPIO_PULLUP_ENABLE) {
             gpio_set_pull_mode(scl_io_num, GPIO_PULLUP_ONLY);


### PR DESCRIPTION
If we use I2C in slave mode, we can use input-only pin for SCL line (GPI 34-39).
But there is a problem in i2c_set_pin() which is called by i2c_param_config().
In case of using GPI as SCL the following statements are failed:
	1. gpio_set_level(scl_io_num, I2C_IO_INIT_LEVEL);
Function fails because it cannot set level for input pin. As a result a ESP_LOGE() is called.
	2. gpio_set_direction(scl_io_num, GPIO_MODE_INPUT_OUTPUT_OD);
Function fails because it accepts only GPIO pins. ESP_LOGE() is called, input mode is not enabled for the pin and as a result - no interrupts from the pin.